### PR TITLE
Updated script/readme for dictionary attack variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # osx.pirrit_removal
 Script to remove osx pirrit.
 
+
+[Edit] One variation of pirrit seems to create a lot of these processes/services which need to be removed using random dictionary words in place of com.<name>.plist
+This snippet will grab the eligible app names based on the contents of the plist file (not 100% accurate)
+
+BEFORE:
+Check the output of `grep 'channel\|click_id' /Library/Preferences/*.plist  | cut -d ':' -f 1 | sed 's/.*\///g' | uniq `
+and ensure that the list seems reasonable.
+
+DO NOT run the follow if the list above is empty! 
+
+
+This is the command to exectute:
+` grep 'channel\|click_id' /Library/Preferences/*.plist  | cut -d ':' -f 1 | sed 's/.*\///g' | uniq |  xargs -I {} ./remove_pirrit.sh {}`
+
 Download this script, give it execute permissions (chmod +x) and run it as root (sudo)

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 Script to remove osx pirrit.
 
 
-[Edit] One variation of pirrit seems to create a lot of these processes/services which need to be removed using random dictionary words in place of com.<name>.plist
+**Edit**: One variation of pirrit seems to create a lot of these processes/services which need to be removed using random dictionary words in place of com.<name>.plist
 This snippet will grab the eligible app names based on the contents of the plist file (not 100% accurate)
 
-BEFORE:
-Check the output of `grep 'channel\|click_id' /Library/Preferences/*.plist  | cut -d ':' -f 1 | sed 's/.*\///g' | uniq `
+Download this script, give it execute permissions (chmod +x) 
+
+**BEFORE**:
+Check the output of   
+```grep 'channel\|click_id' /Library/Preferences/*.plist  | cut -d ':' -f 1 | sed 's/.*\///g' | uniq ```
 and ensure that the list seems reasonable.
 
-DO NOT run the follow if the list above is empty! 
+**DO NOT** run the follow if the list above is empty! 
 
 
-This is the command to exectute:
-` grep 'channel\|click_id' /Library/Preferences/*.plist  | cut -d ':' -f 1 | sed 's/.*\///g' | uniq |  xargs -I {} ./remove_pirrit.sh {}`
+This is the command to execute (**NOTE** the following command uses sudo, never execute commands copied from the internet):  
+` grep 'channel\|click_id' /Library/Preferences/*.plist  | cut -d ':' -f 1 | sed 's/.*\///g' | uniq |  xargs -I {} sudo ./remove_pirrit.sh {}`
 
-Download this script, give it execute permissions (chmod +x) and run it as root (sudo)

--- a/remove_pirrit.sh
+++ b/remove_pirrit.sh
@@ -18,7 +18,7 @@ netPrefFileName=$1
 echo "[*] Netperf name is:"
 echo $netPrefFileName
 
-echo "[*] Getting appname from com.common.plist"
+echo "[*] Getting appname from $1"
 appName=$(echo $netPrefFileName  | sed 's/com\.//g' | sed 's/\.plist//g')
 echo $appName
 
@@ -51,4 +51,4 @@ echo “[*] Removing pirrit launching script”
 sudo rm "/etc/"$appName".sh"
 sudo rm "/etc/"$appName".conf"
 
-echo “Script finished\n”
+echo “Script finished”

--- a/remove_pirrit.sh
+++ b/remove_pirrit.sh
@@ -6,14 +6,20 @@ echo "If this command has an output then continue running this script. Else DONT
 echo "Press any key to continue running this script, remember - I am not responsible for any unfortunate outcomes"
 read
 
+if [ $# -eq 0 ]
+  then
+      echo "No arguments supplied, this was dangerous... but disaster has been avoided.  Read the README if you are unsure why this happened"
+      exit
+fi
+
 echo "[*] Getting net_pref name"
-netPrefFileName=$(sudo defaults read /Library/Preferences/com.common.plist net_pref)
+netPrefFileName=$1
 
 echo "[*] Netperf name is:"
 echo $netPrefFileName
 
 echo "[*] Getting appname from com.common.plist"
-appName=$(sudo defaults read /Library/Preferences/com.common.plist name)
+appName=$(echo $netPrefFileName  | sed 's/com\.//g' | sed 's/\.plist//g')
 echo $appName
 
 echo "[*] Stopping and removing LaunchDaemon"
@@ -21,6 +27,7 @@ sudo launchctl unload -w "/Library/LaunchDaemons/"$netPrefFileName
 sudo killall $appName
 
 sudo rm "/Library/LaunchDaemons/"$netPrefFileName
+sudo rm "/Library/Preferences/"$netPrefFileName
 
 echo "[*] Removing injector"
 sudo rm -r "/Library/"$appName
@@ -29,26 +36,19 @@ sudo rm /etc/change_net_settings.sh
 
 sudo pfctl -evf /etc/pf.conf
 
-servicePrefFileName=$(sudo defaults read /Library/Preferences/com.common.plist service_pref)
-echo “[*] Net pref file name:”
-echo $netPrefFileName
-
-appName=$(sudo defaults read /Library/Preferences/com.common.plist name)
-echo “[*] App name is:”
-echo $appName
-
 echo “[*] Removing LaunchDaemon”
-sudo launchctl unload -w "/Library/LaunchDaemons/"$servicePrefFileName
+sudo launchctl unload -w "/Library/LaunchDaemons/"$netPrefFileName
 echo [*] Killing app and osascript”
 sudo killall $appName
 sudo killall osascript
 
 echo “[*] Cleaning up…”
-sudo rm "/Library/LaunchDaemons/"$servicePrefFileName
+sudo rm "/Library/LaunchDaemons/"$netPrefFileName
 
 sudo rm -r "/Library/"$appName
 
 echo “[*] Removing pirrit launching script”
-sudo rm /etc/run_app.sh
+sudo rm "/etc/"$appName".sh"
+sudo rm "/etc/"$appName".conf"
 
 echo “Script finished\n”


### PR DESCRIPTION
One variation of pirrit seems to create a lot of these processes/services which need to be removed using random dictionary words in place of com.<name>.plist

This edit basically grabs eligible service names using grep and xargs and pipes each one into the script in sequence.
